### PR TITLE
feat: ignore sudo error on ACK

### DIFF
--- a/docs/neutron-core/contract-manager/client.md
+++ b/docs/neutron-core/contract-manager/client.md
@@ -24,12 +24,12 @@ service Query {
 }
 ```
 
-### all-failures
+### failures [address]
 
 Returns list of all failures.
 
-```bash
-neutrond query contractmanager all-failures
+```shell
+neutrond query contractmanager failures
 ```
 
 <details>
@@ -37,12 +37,12 @@ neutrond query contractmanager all-failures
   Returns info about all failures:
 
   ```shell
-  neutrond query contractmanager all-failures
+  neutrond query contractmanager failures
   ```
 
 Output:
 
-  ```shell
+  ```yaml
   failures:
     - address: neutron1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqcd0mrx
       id: 0
@@ -60,12 +60,11 @@ Output:
 </details>
 
 
-### contract-failures [address]
 
 Returns list of all failures for specific contract address.
 
 ```bash
-neutrond query contractmanager contract-failures [address]
+neutrond query contractmanager failures [address]
 ```
 
 <details>
@@ -73,12 +72,12 @@ neutrond query contractmanager contract-failures [address]
   Returns failures for specific contract address:
 
   ```shell
-  neutrond query contractmanager contract-failures neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq
+  neutrond query contractmanager failures neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq
   ```
 
 Output:
 
-  ```shell
+  ```yaml
   failures:
     - address: neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq
       id: 0
@@ -94,3 +93,4 @@ Output:
   ```
 
 </details>
+

--- a/docs/neutron-core/contract-manager/client.md
+++ b/docs/neutron-core/contract-manager/client.md
@@ -1,0 +1,96 @@
+# Client
+
+## Queries
+
+In this section we describe the queries required on grpc server.
+
+```protobuf
+// Query defines the gRPC querier service.
+service Query {
+	// Parameters queries the parameters of the module.
+	rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
+		option (google.api.http).get = "/neutron-org/neutron/contractmanager/params";
+	}
+	// Queries a Failures by address.
+	rpc Failure(QueryGetFailuresByAddressRequest) returns (QueryGetFailuresByAddressResponse) {
+		option (google.api.http).get = "/neutron-org/neutron/contractmanager/failure/{address}";
+	}
+
+	// Queries a list of failed addresses.
+	rpc AllFailures(QueryAllFailureRequest) returns (QueryAllFailureResponse) {
+		option (google.api.http).get = "/neutron-org/neutron/contractmanager/failure";
+	}
+
+}
+```
+
+### all-failures
+
+Returns list of all failures.
+
+```bash
+neutrond query contractmanager all-failures
+```
+
+<details>
+  <summary>Example</summary>
+  Returns info about all failures:
+
+  ```shell
+  neutrond query contractmanager all-failures
+  ```
+
+Output:
+
+  ```shell
+  failures:
+    - address: neutron1nc5tatafv6eyq7llkr2gv50ff9e22mnf70qgjlv737ktmt4eswrqcd0mrx
+      id: 0
+      ack_id: 0
+      ack_type: "ack"
+    - address: neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq
+      id: 1
+      ack_id: 1
+      ack_type: "timeout"
+  pagination:
+    next_key: null
+    total: "2"
+  ```
+
+</details>
+
+
+### contract-failures [address]
+
+Returns list of all failures for specific contract address.
+
+```bash
+neutrond query contractmanager contract-failures [address]
+```
+
+<details>
+  <summary>Example</summary>
+  Returns failures for specific contract address:
+
+  ```shell
+  neutrond query contractmanager contract-failures neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq
+  ```
+
+Output:
+
+  ```shell
+  failures:
+    - address: neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq
+      id: 0
+      ack_id: 0
+      ack_type: "ack"
+    - address: neutron14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s5c2epq
+      id: 1
+      ack_id: 1
+      ack_type: "ack"
+  pagination:
+    next_key: null
+    total: "2"
+  ```
+
+</details>

--- a/docs/neutron-core/contract-manager/overview.md
+++ b/docs/neutron-core/contract-manager/overview.md
@@ -19,5 +19,5 @@ But at the same time there is gas consumption for the sudo call. Two options for
 1. Allocate only a certain amount of gas per sudo handler call, thereby limiting the handler's computational capabilities. The volume of the dediated amount of gas can be regulated by the help of governance proposal
 2. Release gas dynamically depending on the remaining gas and the gas reserve required to complete the call with a failure record in the state.
 
-In this implementation, the second approach was used.
+In this implementation, the second approach was used. Also given the fact that Neutron makes the contract pay for all packets (using ibc fees), it's hard to spam / overflow neutron with failure records.
 

--- a/docs/neutron-core/contract-manager/overview.md
+++ b/docs/neutron-core/contract-manager/overview.md
@@ -1,0 +1,23 @@
+# Overview
+
+## Abstract
+
+This document specifies the ContractManager module for the Neutron network.
+
+The ContractManager module implements a mechanism and contains methods to make sudo calls to the contracts as well it helps to store sudo handler calls errors during IBC ACK.
+
+## Concepts
+
+Due to the fact that contracts are allowed to make calls to the IBC, as well as process all received data, a problem arises in which a malicious contract can make a call to the IBC and, during the response of the ACK, make an error in the sudo handler, or simply do not implement it. Which will lead to disruption of the channel (in the case of a ORDERED channel), or force the relayer to send ACK requests over and over again, thereby loading the nodes serving the blockchain.
+
+In order to avoid this problem, the code in the module from which the sudo handler is called should ignore the error and instead return the success status of the call.
+But this in turn exposes the problem of informing the owner of the contract that a failure has occurred. To do this, in case of an unsuccessful call, the module from which the sudo handler is called must call the `AddContractFailure` method of the `keeper` of the `ContractManager` module.
+
+To ensure that the state of the contract is consistent, the call to the sudo handler takes place in a temporary state (using `CacheContext`), which is written to the active state if the call succeeds.
+
+But at the same time there is gas consumption for the sudo call. Two options for gas limitation were proposed:
+1. Allocate only a certain amount of gas per sudo handler call, thereby limiting the handler's computational capabilities. The volume of the dediated amount of gas can be regulated by the help of governance proposal
+2. Release gas dynamically depending on the remaining gas and the gas reserve required to complete the call with a failure record in the state.
+
+In this implementation, the second approach was used.
+

--- a/docs/neutron-core/contract-manager/state.md
+++ b/docs/neutron-core/contract-manager/state.md
@@ -1,0 +1,6 @@
+# State
+
+The ContractManager module stores one [Failure](TODO: Put link to the Contract Manager genesis) per contract address and record id.
+`Failure` contains all the necessary info to store data about ACK sudo handler call failure. `address` contains contract addres and it is used in conjunction with  `id` field to create index of the record in the `KVStore`. `ack_id` is used to identify ACK request that was failed, `ack_type` can take two values : `ack`, and `timeout`.
+
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -55,6 +55,15 @@ const sidebars = {
                         },
                         {
                             type: 'category',
+                            label: 'Contract Manager',
+                            items: [
+                                'neutron-core/contract-manager/overview',
+                                'neutron-core/contract-manager/client',
+                                'neutron-core/contract-manager/state'                                
+                            ]
+                        },                        
+                        {
+                            type: 'category',
                             label: 'Transfer',
                             items: [
                                 'neutron-core/transfer/overview',


### PR DESCRIPTION
In this PR documentation for issue #2 from the audit report will be added.

In case of Sudo handler error state of the contract will be reverted and ACK as well as acknowledgement identifiers will be stored in the store. New module to get list of failed acks ids with contracts addresses will be added. Module name will be `contractmanager`

1. [Module PR](https://github.com/neutron-org/neutron/pull/84)

More info: https://p2pvalidator.atlassian.net/browse/NTRN-253