### PR TITLE
NTRN-346 swap treasury & reserve names

### DIFF
--- a/docs/neutron/dao/overview.md
+++ b/docs/neutron/dao/overview.md
@@ -93,9 +93,9 @@ be executed.
 There is a special *Security subDAO* that can only execute *pause()* methods on the following contracts:
 
 1. All other subDAOs;
-2. [Treasury](/docs/neutron/tokenomics/treasury/overview.md) contract;
+2. [Reserve](/docs/neutron/tokenomics/reserve/overview.md) contract;
 3. [Distribution](/docs/neutron/tokenomics/distribution/overview.md) contract;
-4. [Reserve](/docs/neutron/tokenomics/reserve/overview.md) contract.
+4. [Treasury](/docs/neutron/tokenomics/treasury/overview.md) contract.
 
 The Security subDAO implements a modified version of the single-choice proposal that only allows to send `pause()`
 messages to smart contracts.

--- a/docs/neutron/feeburner/overview.md
+++ b/docs/neutron/feeburner/overview.md
@@ -4,12 +4,12 @@
 
 This document specifies the FeeBurner module for the Neutron network.
 
-The FeeBurner module is called in the end of processing of every block and manages consumer part of fees: all Neutron fees are burned and fees in any other denom are sent to Treasury.
+The FeeBurner module is called in the end of processing of every block and manages consumer part of fees: all Neutron fees are burned and fees in any other denom are sent to Reserve.
 
 ## Params
 
 - `NeutronDenom` — denom of Neutron token, fees in Neutrons are burned;
-- `TreasuryAddress` — address of Neutron Treasury smart contract, fees in all non-Neutron tokens will be transfered here.
+- `ReserveAddress` — address of Neutron Reserve smart contract, fees in all non-Neutron tokens will be transfered here.
 
 ## Concepts
 

--- a/docs/neutron/tokenomics/overview.md
+++ b/docs/neutron/tokenomics/overview.md
@@ -6,9 +6,9 @@ Transaction fees constitute Neutron’s main source of revenue. They originate f
 transactions through Neutron’s IBC fee model. Transaction fees are paid in NTRN or ATOM tokens.
 
 - 25% of the fees are sent to the hub as payment for ICS;
-- The remaining 75% are either burnt (NTRN) or sent to the Treasury (ATOM, etc.).
+- The remaining 75% are either burnt (NTRN) or sent to the Reserve (ATOM, etc.).
 
-## Treasury, Treasury and Distribution Contract
+## Reserve, Treasury and Distribution Contract
 
 There are 3 contracts that manage Neutron’s funds:
 

--- a/docs/neutron/tokenomics/overview.md
+++ b/docs/neutron/tokenomics/overview.md
@@ -6,9 +6,9 @@ Transaction fees constitute Neutron’s main source of revenue. They originate f
 transactions through Neutron’s IBC fee model. Transaction fees are paid in NTRN or ATOM tokens.
 
 - 25% of the fees are sent to the hub as payment for ICS;
-- The remaining 75% are either burnt (NTRN) or sent to the Lorem (ATOM, etc.).
+- The remaining 75% are either burnt (NTRN) or sent to the Treasury (ATOM, etc.).
 
-## Lorem, Treasury and Distribution Contract
+## Treasury, Treasury and Distribution Contract
 
 There are 3 contracts that manage Neutron’s funds:
 

--- a/docs/neutron/tokenomics/overview.md
+++ b/docs/neutron/tokenomics/overview.md
@@ -6,16 +6,16 @@ Transaction fees constitute Neutron’s main source of revenue. They originate f
 transactions through Neutron’s IBC fee model. Transaction fees are paid in NTRN or ATOM tokens.
 
 - 25% of the fees are sent to the hub as payment for ICS;
-- The remaining 75% are either burnt (NTRN) or sent to the Treasury (ATOM, etc.).
+- The remaining 75% are either burnt (NTRN) or sent to the Lorem (ATOM, etc.).
 
-## Treasury, Reserve and Distribution Contract
+## Lorem, Treasury and Distribution Contract
 
 There are 3 contracts that manage Neutron’s funds:
 
-- [The Treasury](treasury/overview) holds the vested NTRNs and sends them to the Reserve and Distribution contracts. Treasury tokens are
+- [The Reserve](reserve/overview) holds the vested NTRNs and sends them to the Treasury and Distribution contracts. Reserve tokens are
   vested based on on-chain activity: the more NTRN tokens are burned while processing block fees (see above), the more
-  tokens get unlocked in the treasury;
-- [The Reserve](reserve/overview) contract keeps the funds that have already vested, but were not sent to the Distribution contract. It
+  tokens get unlocked in the reserve;
+- [The Treasury](treasury/overview) contract keeps the funds that have already vested, but were not sent to the Distribution contract. It
   is used by the [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao) for one-off payouts;
 - [The Distribution](distribution/overview) contract is responsible for the second step of token distribution where tokens sent to this
   contract are distributed between `share holders`, where `share holders` are a configurable set of addresses with

--- a/docs/neutron/tokenomics/reserve/messages.md
+++ b/docs/neutron/tokenomics/reserve/messages.md
@@ -1,61 +1,100 @@
 # Messages
 
-## Instantiate
-
-Instantiated with this message:
-
+## InstantiateMsg
 ```rust
 pub struct InstantiateMsg {
-    /// Denom in which Reserve will hold it's funds.
-    pub denom: String,
-
-    /// The address of the Neutron DAO. It's capable of pausing and unpausing the contract.
+    /// Address of the Neutron DAO contract
     pub main_dao_address: String,
 
-    /// The address of the DAO guardian. The security DAO is capable only of pausing the contract.
+    /// Denom of the main coin
+    pub denom: String,
+
+    /// Distribution rate [0;1] which goes to distribution contract
+    pub distribution_rate: Decimal,
+
+    /// Minimum period between distribution calls
+    pub min_period: u64,
+
+    /// Address of distribution contract
+    pub distribution_contract: String,
+
+    /// Address of treasury contract
+    pub treasury_contract: String,
+
+    /// Address of security DAO contract
     pub security_dao_address: String,
+
+    /// Vesting release function denominator
+    pub vesting_denominator: u128,
 }
 ```
 
-> **Note:** uploading and instantiation was already done before the chain start.
-
 ## ExecuteMsg
-
-Contract takes following messages:
-
 ```rust
+#[pausable]
 pub enum ExecuteMsg {
     /// Transfer the contract's ownership to another account [permissioned - executable only by Neutron DAO]
     TransferOwnership(String),
 
-    /// Payout specified `amount` of funds to the `recipient` address [permissioned - executable only by Neutron DAO]
-    Payout {
-        amount: Uint128,
-        recipient: String,
+    /// Distribute pending funds between Bank and Distribution accounts [permissionless]
+    Distribute {},
+
+    /// Update config [permissioned - executable only by Neutron DAO]
+    UpdateConfig {
+        distribution_rate: Option<Decimal>,
+        min_period: Option<u64>,
+        distribution_contract: Option<String>,
+        treasury_contract: Option<String>,
+        security_dao_address: Option<String>,
+        vesting_denominator: Option<u128>,
     },
 
-    /// Pause the contract for `duration` amount of blocks [permissioned - executable only by Neutron DAO or the Security SubDAO]
+    /// Pause the contract for `duration` amount of blocks [permissioned - executable only by Neutron DAO or the Security DAO]
     Pause { duration: u64 },
-
-    /// Unpause the contract [permissioned - executable only by the Neutron DAO]
+    
+    /// Unpauses the contract [permissioned - executable only by Neutron DAO]
     Unpause {},
 }
 ```
 
-### TransferOwnership
+### TransferOwnership 
 
 Transfer the contract's ownership to another account. Can be executed by `main_dao_address` only.
-This method accepts a single string, which should be an account address of new contract owner.
 
-### Payout
 
-Send specified `amount` of funds to the `recipient` address. Can be executed by `main_dao_address` only.
-Reserve contract only operates on `denom` set during instantiation, and will only pay out funds in this denom.
+### Distribute
+
+Distribute pending funds between Bank and Distribution accounts. Can be executed by any address, but not more than `min_period` of heights between calls.
+
+### UpdateConfig
+
+Update reserve contract configuration. Permissioned, can be executed only by [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao).
+
+```rust
+UpdateConfig {
+    /// Distribution rate [0; 1] which goes to distribution contract
+    distribution_rate: Option<Decimal>,
+
+    /// Minimum period between distribution calls in amount of blocks
+    min_period: Option<u64>,
+
+    /// Address of distribution contract which will receive funds defined by distribution_rate %
+    distribution_contract: Option<String>,
+
+    /// Address of treasury contract, which will receive funds defined by 100-distribution_rate %
+    treasury_contract: Option<String>,
+
+    /// Address of the security DAO contract
+    security_dao_address: Option<String>,
+
+    /// Denominator used in the vesting release function
+    vesting_denominator: Option<u128>,
+```
 
 ### Pause
 
-Pause the contract for `duration` amount of blocks. Can be executed only by `main_dao_address` or `security_dao_address`.
+Pause contract for `duration` amount of blocks. Permissioned can be executed only by [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao) or the Security DAO. If contract is in paused state it disables `execute` method processing for any message except `Pause` and `Unpause`.
 
 ### Unpause
 
-Unpause the contract. Can be executed by `main_dao_address_only`.
+Unpause paused contract. Permissioned can be executed only by [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao).

--- a/docs/neutron/tokenomics/reserve/overview.md
+++ b/docs/neutron/tokenomics/reserve/overview.md
@@ -1,19 +1,33 @@
 # Overview
 
-This document describes the Reserve contract for the Neutron network. The Reserve contract keeps and distributes funds
-vested from Treasury in the form of one-off payments.
+This document describes the Reserve contract for the Neutron network.
+
+**The Reserve** contract holds the vested NTRNs, and sends them to the [Treasury](../treasury/overview.md) and [Distribution](../distribution/overview.md) contracts. This contract is owned by the [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao) and is instantiated at genesis. It is responsible for the first step of tokens
+distribution.
+
+Reserve contract can be configured only by the [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao). The `distribute` call is permissionless and can be called by anybody.
+
+Reserve coins are vested based on on-chain activity: the more NTRN coins are burned while processing block fees (see above), the more tokens distributed from the Reserve.
+
+In order to distribute coins any address can execute `distribute` call, this method is triggered by a transaction and distributes coins from a treasure. 
+It starts by loading configuration parameters such as the denomination of the currency, minimum period between distributions, and the distribution rate.
+
+The function checks if the time since the last distribution is less than the minimum period. If it is, then the function returns an `ContractError::TooSoonToDistribute` error indicating that it is too soon to distribute. The time of the last distribution is saved for future reference. The current balance of the contract is retrieved from the interchain querier. If there are no funds, then the function returns an `ContractError::NoFundsToDistribute` error indicating that there are no funds to distribute.
+
+Also it calculates the amount of burned coins for the period and adjusts it using the `safe_burned_coins_for_period` function to prevent arithmetic overflow. If there are no burned coins, then the function returns an `ContractError::NoBurnedCoins` error indicating that there are no burned coins. The balance to distribute is calculated using the `vesting_function`.
+
+The `vesting_function` calculates the amount of coins to be distributed (released)we use following expression: $burnt\_tokens \times multiplier$ based on the formula $multiplier = (\frac{configurable\_denominator-1}{configurable\_denominator})^{burnt\_tokens} * x$, where $x$ is the current balance in the treasure and ${burnt\_tokens}$ is the number of burned coins in a period of time. The original formula $multiplier = \frac{x}{configurable\_denominator}$ was optimized and current formula was used in order to make the calculation more efficient and faster. Otherwise it will be required to calculate released coins on every burned coin but this is may be time and resource consuming.
+
+The $configurable\_denominator$ should be
+set based on coins burning rate and preferred total duration of vesting. Take into account that while initially one
+burnt tokens equals multiple NTRN tokens made liquid, the flow of new tokens into the Reserve progressively slows down
+until the tokens supply is exhausted and the tokenomics becomes deflationary.
+
+The final result is rounded up to the nearest integer and returned as a `Uint128` type.
+
+The amount of coins to distribute and the amount of coins to reserve are then calculated. The distribution stats are updated and a response is created indicating the amount of coins distributed, the amount of coins reserved, and a tag indicating the action as "neutron/reserve/distribute".
 
 ## Deployment
 
-This is one of the contracts that are initialized at Neutron genesis. The [initialization message](messages#instantiate)
-contains [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao) and Security SubDAO address.
-
-## Description
-
-Contract gets the funds from the [Treasury contract](../treasury/overview) that didn't go
-to [Distribution contract](../distribution/overview).
-
-These funds are used for [one-off payments](messages#payout) to specified address. One-off payments can only be made by
-the decision of the [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao).
-
-Can be [paused](messages#pause) or [unpaused](messages#unpause).
+This is one of the contracts that are initialized at Neutron genesis. [Initialization message](./messages.md) contains The Neutron DAO and
+Security DAO addresses.

--- a/docs/neutron/tokenomics/reserve/queries.md
+++ b/docs/neutron/tokenomics/reserve/queries.md
@@ -1,44 +1,77 @@
 # Queries
 
-This contract accepts these query msgs:
-
 ```rust
+#[pausable_query]
 pub enum QueryMsg {
-    /// The contract's configuration
-    Config {}, // returns `Config`
+    /// The contract's configurations; returns [`Config`]
+    Config {},
 
-    /// The contract's pause info
-    PauseInfo {}, // returns `PauseInfoResponse`
+    /// The contract's current stats; returns [`StatsResponse`]
+    Stats {},
 }
 ```
 
 ## Config
 
-Returns the current config for Reserve contract:
+Returns current reserve contract configuration. Returns an object with following schema:
+
 
 ```rust
 pub struct Config {
-    /// Denom in which Reserve holds it's funds.
+    /// Distribution rate (0-1) which goes to distribution contract
+    pub distribution_rate: Decimal,
+
+    /// Address of distribution contract, which will receive funds defined but distribution_rate %
+    pub distribution_contract: Addr,
+
+    /// Address of treasury contract, which will receive funds defined by 100-distribution_rate %
+    pub treasury_contract: Addr,
+
+    /// Minimum period between distribution calls
+    pub min_period: u64,
+
+    /// Denom of the main coin
     pub denom: String,
 
-    /// The address of the Neutron DAO. It's capable of pausing and unpausing the contract.
+    /// Address of the Neutron DAO contract
     pub main_dao_address: Addr,
 
-    /// The address of the DAO guardian. The security DAO is capable only of pausing the contract.
+    /// Address of the security DAO contract
     pub security_dao_address: Addr,
+
+    // Denominator used in the vesting release function
+    pub vesting_denominator: u128,
+}
+```
+
+## Stats
+
+Returns contract coins distribution stats. Returns an object with following schema:
+
+```rust
+pub struct StatsResponse {
+    /// Amount of coins distributed since contract instantiation
+    pub total_distributed: Uint128,
+
+    /// Amount of coins reserved since contract instantiation
+    pub total_reserved: Uint128,
+
+    /// Total amount of burned coins processed by reserve contract
+    pub total_processed_burned_coins: Uint128,
 }
 ```
 
 ## PauseInfo
 
-Returns the current pause info for the Reserve contract:
+Returns pause state info. Returns an object with following schema:
 
 ```rust
 pub enum PauseInfoResponse {
-    /// Contract is paused until `until_height` block is reached
+    /// Contract is in paused state until `until_height` chain height
     Paused { until_height: u64 },
 
     /// Contract is not paused
     Unpaused {},
 }
+
 ```

--- a/docs/neutron/tokenomics/treasury/messages.md
+++ b/docs/neutron/tokenomics/treasury/messages.md
@@ -1,100 +1,61 @@
-# Messages
+o# Messages
 
-## InstantiateMsg
+## Instantiate
+
+Instantiated with this message:
+
 ```rust
 pub struct InstantiateMsg {
-    /// Address of the Neutron DAO contract
-    pub main_dao_address: String,
-
-    /// Denom of the main coin
+    /// Denom in which Treasury will hold it's funds.
     pub denom: String,
 
-    /// Distribution rate [0;1] which goes to distribution contract
-    pub distribution_rate: Decimal,
+    /// The address of the Neutron DAO. It's capable of pausing and unpausing the contract.
+    pub main_dao_address: String,
 
-    /// Minimum period between distribution calls
-    pub min_period: u64,
-
-    /// Address of distribution contract
-    pub distribution_contract: String,
-
-    /// Address of reserve contract
-    pub reserve_contract: String,
-
-    /// Address of security DAO contract
+    /// The address of the DAO guardian. The security DAO is capable only of pausing the contract.
     pub security_dao_address: String,
-
-    /// Vesting release function denominator
-    pub vesting_denominator: u128,
 }
 ```
 
+> **Note:** uploading and instantiation was already done before the chain start.
+
 ## ExecuteMsg
+
+Contract takes following messages:
+
 ```rust
-#[pausable]
 pub enum ExecuteMsg {
     /// Transfer the contract's ownership to another account [permissioned - executable only by Neutron DAO]
     TransferOwnership(String),
 
-    /// Distribute pending funds between Bank and Distribution accounts [permissionless]
-    Distribute {},
-
-    /// Update config [permissioned - executable only by Neutron DAO]
-    UpdateConfig {
-        distribution_rate: Option<Decimal>,
-        min_period: Option<u64>,
-        distribution_contract: Option<String>,
-        reserve_contract: Option<String>,
-        security_dao_address: Option<String>,
-        vesting_denominator: Option<u128>,
+    /// Payout specified `amount` of funds to the `recipient` address [permissioned - executable only by Neutron DAO]
+    Payout {
+        amount: Uint128,
+        recipient: String,
     },
 
-    /// Pause the contract for `duration` amount of blocks [permissioned - executable only by Neutron DAO or the Security DAO]
+    /// Pause the contract for `duration` amount of blocks [permissioned - executable only by Neutron DAO or the Security SubDAO]
     Pause { duration: u64 },
-    
-    /// Unpauses the contract [permissioned - executable only by Neutron DAO]
+
+    /// Unpause the contract [permissioned - executable only by the Neutron DAO]
     Unpause {},
 }
 ```
 
-### TransferOwnership 
+### TransferOwnership
 
 Transfer the contract's ownership to another account. Can be executed by `main_dao_address` only.
+This method accepts a single string, which should be an account address of new contract owner.
 
+### Payout
 
-### Distribute
-
-Distribute pending funds between Bank and Distribution accounts. Can be executed by any address, but not more than `min_period` of heights between calls.
-
-### UpdateConfig
-
-Update treasury contract configuration. Permissioned, can be executed only by [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao).
-
-```rust
-UpdateConfig {
-    /// Distribution rate [0; 1] which goes to distribution contract
-    distribution_rate: Option<Decimal>,
-
-    /// Minimum period between distribution calls in amount of blocks
-    min_period: Option<u64>,
-
-    /// Address of distribution contract which will receive funds defined by distribution_rate %
-    distribution_contract: Option<String>,
-
-    /// Address of reserve contract, which will receive funds defined by 100-distribution_rate %
-    reserve_contract: Option<String>,
-
-    /// Address of the security DAO contract
-    security_dao_address: Option<String>,
-
-    /// Denominator used in the vesting release function
-    vesting_denominator: Option<u128>,
-```
+Send specified `amount` of funds to the `recipient` address. Can be executed by `main_dao_address` only.
+Treasury contract only operates on `denom` set during instantiation, and will only pay out funds in this denom.
 
 ### Pause
 
-Pause contract for `duration` amount of blocks. Permissioned can be executed only by [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao) or the Security DAO. If contract is in paused state it disables `execute` method processing for any message except `Pause` and `Unpause`.
+Pause the contract for `duration` amount of blocks. Can be executed only by `main_dao_address` or `security_dao_address`.
 
 ### Unpause
 
-Unpause paused contract. Permissioned can be executed only by [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao).
+Unpause the contract. Can be executed by `main_dao_address_only`.

--- a/docs/neutron/tokenomics/treasury/overview.md
+++ b/docs/neutron/tokenomics/treasury/overview.md
@@ -1,33 +1,19 @@
 # Overview
 
-This document describes the Treasury contract for the Neutron network.
-
-**The Treasury** contract holds the vested NTRNs, and sends them to the [Reserve](../reserve/overview.md) and [Distribution](../distribution/overview.md) contracts. This contract is owned by the [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao) and is instantiated at genesis. It is responsible for the first step of tokens
-distribution.
-
-Treasury contract can be configured only by the [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao). The `distribute` call is permissionless and can be called by anybody.
-
-Treasury coins are vested based on on-chain activity: the more NTRN coins are burned while processing block fees (see above), the more tokens distributed from the Treasury.
-
-In order to distribute coins any address can execute `distribute` call, this method is triggered by a transaction and distributes coins from a treasure. 
-It starts by loading configuration parameters such as the denomination of the currency, minimum period between distributions, and the distribution rate.
-
-The function checks if the time since the last distribution is less than the minimum period. If it is, then the function returns an `ContractError::TooSoonToDistribute` error indicating that it is too soon to distribute. The time of the last distribution is saved for future reference. The current balance of the contract is retrieved from the interchain querier. If there are no funds, then the function returns an `ContractError::NoFundsToDistribute` error indicating that there are no funds to distribute.
-
-Also it calculates the amount of burned coins for the period and adjusts it using the `safe_burned_coins_for_period` function to prevent arithmetic overflow. If there are no burned coins, then the function returns an `ContractError::NoBurnedCoins` error indicating that there are no burned coins. The balance to distribute is calculated using the `vesting_function`.
-
-The `vesting_function` calculates the amount of coins to be distributed (released)we use following expression: $burnt\_tokens \times multiplier$ based on the formula $multiplier = (\frac{configurable\_denominator-1}{configurable\_denominator})^{burnt\_tokens} * x$, where $x$ is the current balance in the treasure and ${burnt\_tokens}$ is the number of burned coins in a period of time. The original formula $multiplier = \frac{x}{configurable\_denominator}$ was optimized and current formula was used in order to make the calculation more efficient and faster. Otherwise it will be required to calculate released coins on every burned coin but this is may be time and resource consuming.
-
-The $configurable\_denominator$ should be
-set based on coins burning rate and preferred total duration of vesting. Take into account that while initially one
-burnt tokens equals multiple NTRN tokens made liquid, the flow of new tokens into the Treasury progressively slows down
-until the tokens supply is exhausted and the tokenomics becomes deflationary.
-
-The final result is rounded up to the nearest integer and returned as a `Uint128` type.
-
-The amount of coins to distribute and the amount of coins to reserve are then calculated. The distribution stats are updated and a response is created indicating the amount of coins distributed, the amount of coins reserved, and a tag indicating the action as "neutron/treasury/distribute".
+This document describes the Treasury contract for the Neutron network. The Treasury contract keeps and distributes funds
+vested from Reserve in the form of one-off payments.
 
 ## Deployment
 
-This is one of the contracts that are initialized at Neutron genesis. [Initialization message](./messages.md) contains The Neutron DAO and
-Security DAO addresses.
+This is one of the contracts that are initialized at Neutron genesis. The [initialization message](messages#instantiate)
+contains [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao) and Security SubDAO address.
+
+## Description
+
+Contract gets the funds from the [Reserve contract](../reserve/overview) that didn't go
+to [Distribution contract](../distribution/overview).
+
+These funds are used for [one-off payments](messages#payout) to specified address. One-off payments can only be made by
+the decision of the [Neutron DAO](/docs/neutron/dao/overview.md#neutron-dao).
+
+Can be [paused](messages#pause) or [unpaused](messages#unpause).

--- a/docs/neutron/tokenomics/treasury/queries.md
+++ b/docs/neutron/tokenomics/treasury/queries.md
@@ -1,77 +1,44 @@
 # Queries
 
-```rust
-#[pausable_query]
-pub enum QueryMsg {
-    /// The contract's configurations; returns [`Config`]
-    Config {},
+This contract accepts these query msgs:
 
-    /// The contract's current stats; returns [`StatsResponse`]
-    Stats {},
+```rust
+pub enum QueryMsg {
+    /// The contract's configuration
+    Config {}, // returns `Config`
+
+    /// The contract's pause info
+    PauseInfo {}, // returns `PauseInfoResponse`
 }
 ```
 
 ## Config
 
-Returns current treasury contract configuration. Returns an object with following schema:
-
+Returns the current config for Treasury contract:
 
 ```rust
 pub struct Config {
-    /// Distribution rate (0-1) which goes to distribution contract
-    pub distribution_rate: Decimal,
-
-    /// Address of distribution contract, which will receive funds defined but distribution_rate %
-    pub distribution_contract: Addr,
-
-    /// Address of reserve contract, which will receive funds defined by 100-distribution_rate %
-    pub reserve_contract: Addr,
-
-    /// Minimum period between distribution calls
-    pub min_period: u64,
-
-    /// Denom of the main coin
+    /// Denom in which Treasury holds it's funds.
     pub denom: String,
 
-    /// Address of the Neutron DAO contract
+    /// The address of the Neutron DAO. It's capable of pausing and unpausing the contract.
     pub main_dao_address: Addr,
 
-    /// Address of the security DAO contract
+    /// The address of the DAO guardian. The security DAO is capable only of pausing the contract.
     pub security_dao_address: Addr,
-
-    // Denominator used in the vesting release function
-    pub vesting_denominator: u128,
-}
-```
-
-## Stats
-
-Returns contract coins distribution stats. Returns an object with following schema:
-
-```rust
-pub struct StatsResponse {
-    /// Amount of coins distributed since contract instantiation
-    pub total_distributed: Uint128,
-
-    /// Amount of coins reserved since contract instantiation
-    pub total_reserved: Uint128,
-
-    /// Total amount of burned coins processed by treasury contract
-    pub total_processed_burned_coins: Uint128,
 }
 ```
 
 ## PauseInfo
 
-Returns pause state info. Returns an object with following schema:
+Returns the current pause info for the Treasury contract:
 
 ```rust
 pub enum PauseInfoResponse {
-    /// Contract is in paused state until `until_height` chain height
+    /// Contract is paused until `until_height` block is reached
     Paused { until_height: u64 },
 
     /// Contract is not paused
     Unpaused {},
 }
-
 ```

--- a/sidebars.js
+++ b/sidebars.js
@@ -91,20 +91,20 @@ const sidebars = {
                         'neutron/tokenomics/overview',
                         {
                             type: 'category',
-                            label: 'Treasury',
-                            items: [
-                                'neutron/tokenomics/treasury/overview',
-                                'neutron/tokenomics/treasury/messages',
-                                'neutron/tokenomics/treasury/queries'
-                            ]
-                        },
-                        {
-                            type: 'category',
                             label: 'Reserve',
                             items: [
                                 'neutron/tokenomics/reserve/overview',
                                 'neutron/tokenomics/reserve/messages',
                                 'neutron/tokenomics/reserve/queries'
+                            ]
+                        },
+                        {
+                            type: 'category',
+                            label: 'Treasury',
+                            items: [
+                                'neutron/tokenomics/treasury/overview',
+                                'neutron/tokenomics/treasury/messages',
+                                'neutron/tokenomics/treasury/queries'
                             ]
                         },
                         {


### PR DESCRIPTION
[TEST RUN](https://github.com/neutron-org/neutron-tests/actions/runs/4541619854)


Context:

"Btw folks, it's kind of weird that the contract that holds liquid funds is called "Reserve" and the contract that holds the vested fund is called the "Treasury". I think the names should be exchanged. It sucks to have to do it but I think this will create confusion in the future."

Rename treasury to reserve and reserve to treasury.


See also: 
- [Integration Tests PR](https://github.com/neutron-org/neutron-integration-tests/pull/114)
- [Neutron DAO PR](https://github.com/neutron-org/neutron-dao/pull/47)