### PR TITLE
fix: advise users to run `make install`

### DIFF
--- a/docs/neutron/build-and-run/localnet.md
+++ b/docs/neutron/build-and-run/localnet.md
@@ -47,7 +47,7 @@ cargo install ibc-relayer-cli --bin hermes --version 1.4.1 --locked
 ```bash
 git clone https://github.com/neutron-org/neutron-query-relayer
 cd neutron-query-relayer
-make build
+make install
 ```
 
 ## Start Localnet


### PR DESCRIPTION
Previously, documentation advised users to run `make build` instead of `make install`, which didn't make `neutron_query_relayer` available from PATH. This PR aims to fix this problem.