### PR TITLE
feat: NTRN-490. Add global fee module docs

### DIFF
--- a/docs/neutron/modules/3rdparty/cosmoshub/globalfee/overview.md
+++ b/docs/neutron/modules/3rdparty/cosmoshub/globalfee/overview.md
@@ -1,0 +1,5 @@
+# Overview
+
+The Global fee module was supplied by the great folks at [TGrade](https://github.com/confio/tgrade) wave, with modifications from [Cosmos](https://github.com/cosmos/gaia). All credits and big thanks go to the original authors.
+
+More information about used fee system please check [here](https://github.com/cosmos/gaia/blob/release/v8.0.x/docs/modules/globalfee.md).

--- a/sidebars.js
+++ b/sidebars.js
@@ -224,6 +224,19 @@ const sidebars = {
                             type: 'category',
                             items: [
                                 {
+                                    label: 'Cosmos Hub',
+                                    type: 'category',
+                                    items: [
+                                        {
+                                            label: 'Global Fee',
+                                            type: 'category',
+                                            items: [
+                                                'neutron/modules/3rdparty/cosmoshub/globalfee/overview',
+                                            ]
+                                        }
+                                    ],
+                                },
+                                {
                                     type: 'category',
                                     label: 'Osmosis',
                                     items: [


### PR DESCRIPTION
We need to add the [gaia/x/globalfee at main · cosmos/gaia](https://github.com/cosmos/gaia/tree/main/x/globalfee) module to Neutron.

https://p2pvalidator.atlassian.net/browse/NTRN-490

Depends on:
https://github.com/neutron-org/neutron/pull/264