### PR TITLE
add trailingSlash: false

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,7 +15,8 @@ const config = {
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",
-
+  trailingSlash: false,
+  
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: "neutron-org", // Usually your GitHub org/user name.


### PR DESCRIPTION
When clicking on a relative link on for example [token-generation-event/airdrop/overview/](https://docs.neutron.org/neutron/token-generation-event/airdrop/overview/) with the trailing slash present, it won't direct to the correct page. The trailing slash needs to be off for this to be fixed.