### PR TITLE
typo-Update messages.md

### DIFF
--- a/docs/neutron/modules/dex/messages.md
+++ b/docs/neutron/modules/dex/messages.md
@@ -321,7 +321,7 @@ enum LimitOrderType {
 
 ### Overview
 
-Standard Maker limit orders (Good-til-cancelled & Good-til-Time) can be cancelled at any time (even if they have been filled). Once a limit order is cancelled any remaining `TokenIn` as well as `TokenOut` profits are returned to the `Creaator`.
+Standard Maker limit orders (Good-til-cancelled & Good-til-Time) can be cancelled at any time (even if they have been filled). Once a limit order is cancelled any remaining `TokenIn` as well as `TokenOut` profits are returned to the `Creator`.
 
 ### Cancel Limit Order Message
 


### PR DESCRIPTION
# Fix: Corrected typo in documentation file

## Changes
- `docs/neutron/modules/dex/messages.md:324`: "Creaator" corrected to "Creator".

## Purpose
- Improved documentation accuracy and ensured professionalism by fixing the typo.
