### PR TITLE
Fix ICQ service period definitions

### DIFF
--- a/docs/neutron/modules/interchain-queries/overview.md
+++ b/docs/neutron/modules/interchain-queries/overview.md
@@ -46,8 +46,8 @@ Permission to perform `RemoveInterchainQuery` message is based on three paramete
 3. `registered_at_height` — registered query's property representing the Neutron's height the query was registered at.
 
 The permissions to execute `RemoveInterchainQuery` are as follows:
-- within the service period (i.e. if `current_height <= last_submitted_result_local_height + query_submit_timeout && current_height <= registered_at_height + query_submit_timeout`) only the query's owner is permissioned to remove it;
-- beyond the service period (i.e. if `current_height > last_submitted_result_local_height + query_submit_timeout || current_height > registered_at_height + query_submit_timeout`) anyone can remove the query and take the deposit as a reward.
+- within the service period (i.e. if `current_height <= last_submitted_result_local_height + query_submit_timeout || current_height <= registered_at_height + query_submit_timeout`) only the query's owner is permissioned to remove it;
+- beyond the service period (i.e. if `current_height > last_submitted_result_local_height + query_submit_timeout && current_height > registered_at_height + query_submit_timeout`) anyone can remove the query and take the deposit as a reward.
 
 Amount of coins to deposit is defined via parameter (`query_deposit`) controlled by governance proposal.
 


### PR DESCRIPTION
Fix definitions of "within the service period" and "beyond the service period" for permissions to execute `RemoveInterchainQuery`.