### PR TITLE
typo fix inmessages.md

### DIFF
--- a/docs/neutron/modules/interchain-txs/messages.md
+++ b/docs/neutron/modules/interchain-txs/messages.md
@@ -136,7 +136,7 @@ message MsgSubmitTxResponse {
 ```
 
 * `sequence_id` is a channel's sequence_id for outgoing ibc packet. Unique per a channel;
-* `channel` is the src channel name on neutron's side trasaction was submitted from;
+* `channel` is the src channel name on neutron's side transaction was submitted from;
 
 ### IBC Events
 


### PR DESCRIPTION
# Typo Fix in messages.md

## Description

This pull request corrects a typographical error in the `messages.md` file located in the `docs/neutron/modules/interchain-txs` directory.

### Summary of Changes

#### **File:** `docs/neutron/modules/interchain-txs/messages.md`
- **Typo Fix:** Corrected "trasaction" to "transaction."

### Why This Fix Is Important

- Ensures the documentation is accurate and free from typos.
- Improves readability and professionalism of the interchain transaction documentation.

---

## Checklist

- [x] Verified the typo fix.
- [x] Confirmed no other changes were made.
- [x] Followed the contributing guidelines.

---

### Notes for Reviewers

This change is a simple typo correction. Once reviewed, it is ready for merging.

Thank you!
