### PR TITLE
fix typo messages.md

### DIFF
--- a/docs/neutron/modules/interchain-txs/messages.md
+++ b/docs/neutron/modules/interchain-txs/messages.md
@@ -136,7 +136,7 @@ message MsgSubmitTxResponse {
 ```
 
 * `sequence_id` is a channel's sequence_id for outgoing ibc packet. Unique per a channel;
-* `channel` is the src channel name on neutron's side trasaction was submitted from;
+* `channel` is the src channel name on neutron's side transaction was submitted from;
 
 ### IBC Events
 


### PR DESCRIPTION


- Corrected a typo: `trasaction` → `transaction`.
