### PR TITLE
chore: update network endpoints and peers

### DIFF
--- a/resources/endpoints.mdx
+++ b/resources/endpoints.mdx
@@ -12,16 +12,14 @@ This page lists public endpoints for interacting with Neutron networks, includin
 
 | Provider | Endpoint | Status |
 |----------|----------|--------|
-| Neutron | https://rpc-vertexa.neutron-1.neutron.org | Available |
-| Neutron | https://rpc-solara.neutron-1.neutron.org | Available |
+| Neutron | https://rpc-lb.neutron.org | Available |
 | Cosmos Directory | https://rpc.cosmos.directory/neutron | Available |
 
 ### REST API Endpoints
 
 | Provider | Endpoint | Status |
 |----------|----------|--------|
-| Neutron | https://rest-solara.neutron-1.neutron.org | Available |
-| Neutron | https://rest-vertexa.neutron-1.neutron.org | Available |
+| Neutron | https://rest-lb.neutron.org | Available |
 | Cosmos Directory | https://rest.cosmos.directory/neutron | Available |
 
 ### GRPC Endpoints
@@ -29,14 +27,14 @@ This page lists public endpoints for interacting with Neutron networks, includin
 | Provider | Endpoint | Status |
 |----------|----------|--------|
 | Neutron | grpc-lb.neutron.org:80 | Available |
-| Neutron | grpc-kralum.neutron-1.neutron.org:80 | Available |
 
-### Public State Sync Nodes
+### Persistent Peers
 
-The following state sync node serves snapshots every 2000 blocks:
+The following persistent peers can be used to connect to the Neutron network:
 
 ```
-http://rpc-kralum.neutron-1.neutron.org:26657
+dc0dfb99add9da8f7646a66d601eeea8b9efdcd0@peer-1.neutron.org:25556
+74d2aa0ea0dbff2885596d33232284f3e7d8d891@peer-2.neutron.org:25556
 ```
 
 ## Testnet (pion-1)
@@ -45,14 +43,14 @@ http://rpc-kralum.neutron-1.neutron.org:26657
 
 | Provider | Endpoint |
 |----------|----------|
-| Neutron | https://rpc-palvus.pion-1.neutron.org |
+| Neutron | https://rpc-lb-pion.ntrn.tech |
 | Neutron | https://rpc-t.neutron.nodestake.top |
 
 ### REST API Endpoints
 
 | Provider | Endpoint |
 |----------|----------|
-| Neutron | https://rest-palvus.pion-1.neutron.org |
+| Neutron | https://rest-lb-pion.ntrn.tech |
 | Neutron | https://api-t.neutron.nodestake.top |
 
 ## Explorers

--- a/resources/peers.mdx
+++ b/resources/peers.mdx
@@ -11,9 +11,8 @@ This page lists peer information for connecting to Neutron networks.
 ### Seed Nodes
 
 ```
-24f609fb5946ca3a979f40b7f54132c00104433e@p2p-erheim.neutron-1.neutron.org:26656
+41afd7e1cd49b665899b5c4fa8cef74105d6de0b@seed.neutron.org:26656
 20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:19156
-b1c6fa570a184c56d0d736d260b8065d887e717c@p2p-kralum.neutron-1.neutron.org:26656
 f80e07ebb0ae3f11d938e8e224705b1039f000b5@neutron.dhk.org:26656
 ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:19156
 ```
@@ -21,6 +20,8 @@ ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:19156
 ### Persistent Peers
 
 ```
+dc0dfb99add9da8f7646a66d601eeea8b9efdcd0@peer-1.neutron.org:25556
+74d2aa0ea0dbff2885596d33232284f3e7d8d891@peer-2.neutron.org:25556
 e5d2743d9a3de514e4f7b9461bf3f0c1500c58d9@neutron.peer.stakewith.us:39956
 982f968cd6ac567fdddf2170f7da9725ba21693d@51.210.209.49:15600
 8e2af33b3fc9fee81dda7d351a65d93e8ac97409@65.108.71.163:2480
@@ -29,13 +30,6 @@ b119a600d082963d27a9ba9cd762c7c83f00e7d1@81.196.190.108:10083
 2ee64f9f128e8a9f15f47a8f8d0e9cde7351fd17@46.101.193.151:26656
 ce526dc00568900d54dedf2fd2680ddfc7a58c59@138.201.124.215:36656
 5865c2bae7c0403c0c6d90c01556b1b2bb437ef8@51.89.195.173:26656
-```
-
-### Additional P2P Peers
-
-```
-74f3a4a0423e72334f4439b438b29934e5f0dbbd@p2p-xyphion.neutron-1.neutron.org:26656
-65beeffac5c0f29e6c3749687f03b2040d265895@p2p-talzor.neutron-1.neutron.org:26656
 ```
 
 ## Configuration
@@ -52,14 +46,14 @@ nano ~/.neutrond/config/config.toml
 
 ```toml
 # Comma separated list of seed nodes to connect to
-seeds = "24f609fb5946ca3a979f40b7f54132c00104433e@p2p-erheim.neutron-1.neutron.org:26656,20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:19156,b1c6fa570a184c56d0d736d260b8065d887e717c@p2p-kralum.neutron-1.neutron.org:26656,f80e07ebb0ae3f11d938e8e224705b1039f000b5@neutron.dhk.org:26656,ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:19156"
+seeds = "41afd7e1cd49b665899b5c4fa8cef74105d6de0b@seed.neutron.org:26656,20e1000e88125698264454a884812746c2eb4807@seeds.lavenderfive.com:19156,f80e07ebb0ae3f11d938e8e224705b1039f000b5@neutron.dhk.org:26656,ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@seeds.polkachu.com:19156"
 ```
 
 3. Optionally, add some persistent peers:
 
 ```toml
 # Comma separated list of nodes to keep persistent connections to
-persistent_peers = "e5d2743d9a3de514e4f7b9461bf3f0c1500c58d9@neutron.peer.stakewith.us:39956,982f968cd6ac567fdddf2170f7da9725ba21693d@51.210.209.49:15600"
+persistent_peers = "dc0dfb99add9da8f7646a66d601eeea8b9efdcd0@peer-1.neutron.org:25556,74d2aa0ea0dbff2885596d33232284f3e7d8d891@peer-2.neutron.org:25556"
 ```
 
 ## Addrbook


### PR DESCRIPTION
## Changes

- Replaced individual RPC/REST endpoints with unified load balancers
- Removed deprecated kralum, erheim, palvus nodes
- Added new seed.neutron.org and peer-1/peer-2 nodes
- Updated testnet endpoints to use ntrn.tech load balancers
- Cleaned up obsolete sections (state sync, additional P2P peers)

## Testing

All endpoints and peers have been tested for connectivity - 100% online.