### PR TITLE
docs: link OpenChainBench public Neutron RPC latency benchmark

### DIFF
--- a/resources/endpoints.mdx
+++ b/resources/endpoints.mdx
@@ -65,6 +65,13 @@ dc0dfb99add9da8f7646a66d601eeea8b9efdcd0@peer-1.neutron.org:25556
 
 You can check the current status of Neutron endpoints at [status.cosmos.directory/neutron](https://status.cosmos.directory/neutron).
 
+## Public latency benchmarks
+
+OpenChainBench publishes multi-region latency measurements for public Neutron RPC providers, probing the Tendermint `status` method every 60 seconds from Paris, Virginia, and Singapore.
+
+- Dashboard: [openchainbench.com/benchmarks/neutron-rpc](https://openchainbench.com/benchmarks/neutron-rpc)
+- Source: [github.com/ChainBench/openchainbench](https://github.com/ChainBench/openchainbench)
+
 ## Cosmos Directory
 
 The Cosmos Directory provides API proxies for Neutron that automatically route to available RPC and REST endpoints:


### PR DESCRIPTION
Adds a short section on `resources/endpoints.mdx` linking to OpenChainBench's public latency dashboard for Neutron RPC providers.

OpenChainBench (OCB) is an open-source, multi-region latency benchmark for public RPC endpoints. For Neutron it probes the Tendermint `status` method every 60 seconds from Paris (eu-west), Virginia (us-east), and Singapore (ap-southeast) against three keyless providers currently in scope (PublicNode, Polkachu, LavenderFive).

- Dashboard: https://openchainbench.com/benchmarks/neutron-rpc
- Source: https://github.com/ChainBench/openchainbench

Intended as a neutral cross-check for integrators alongside the existing `status.cosmos.directory/neutron` link. Note: `rpc-kralum.neutron-1.neutron.org` returned an SSL handshake failure during the launch audit and was excluded — happy to re-audit once TLS is fixed.

Precedent: similar additions on osmosis-labs/docs#349 and jup-ag/docs#939.